### PR TITLE
feat: add optional sync timeout

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,7 @@ you can provide custom homeservers, too.
 It will start with a full-sync of the room state, so depending on the size of
 your matrix account(s), this may take a moment.
 
+Optional `timeout` (in seconds) can be added.
 ## Changelog
 
 **Unreleased**


### PR DESCRIPTION
When syncing accounts with many rooms default timeout is not enough

This PR add an optional timeout argument passed to SyncSettings